### PR TITLE
Fix anchor link for travels section

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
         <h1>Frank Mayfield</h1>
         <h3>(Yuxuan Xiang)</h3>
         
-        <h2 id="travel">Travels</h2>
+        <h2 id="travels">Travels</h2>
         <p>Click on the locations below to find out the details of my adventures.</p>
 
         <!-- Map container -->


### PR DESCRIPTION
## Summary
- fix mismatched anchor by renaming `<h2 id="travel">` to `<h2 id="travels">`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684af39f36b483329690c4bec25aad48